### PR TITLE
ファイルのアップロードと保存パスの処理のため、FileUplodeControllerを更新

### DIFF
--- a/laravel-project/app/Http/Controllers/FileUplodeController.php
+++ b/laravel-project/app/Http/Controllers/FileUplodeController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\URL;
 use App\Models\Img;
+use Illuminate\Support\Str;
+
 
 
 class FileUplodeController extends Controller
@@ -28,7 +30,8 @@ class FileUplodeController extends Controller
         }
 
         $file_name = $request->file('file')->getClientOriginalName();
-        $file_path = $request->file('file')->storeAs($file_name);
+        $file_path = $request->file('file')->storeAs('public', $file_name);
+        $file_path = Str::after($file_path, 'public/');
 
         // Create a new record in the Img table
         $img = new Img;
@@ -38,7 +41,7 @@ class FileUplodeController extends Controller
         return response()->json([
             'message' => 'File uploaded and record created successfully',
             'img_id' => $img->img_id,
-            'img_path' => asset('storage/'.$file_name)
+            'img_path' => asset('storage/'.$file_path)
         ], 200);
     }
 


### PR DESCRIPTION
#変更内容:
FileUplodeControllerの変更点を以下のように修正しました
ファイルの保存パスを修正し、"public"ディレクトリに明示的に保存するように変更しました。
→元々の状態でも保存できていたのですが一つ上の階層に保存されてしまう場合もありました
![image](https://github.com/Team2-developers/Laravel-dev/assets/102906375/657e9e26-6f61-46d8-a74b-6325fa3e38e5)

保存パスから"public/"の部分を削除するために、Str::after()メソッドを使用しました。
→publicがurlに含まれていると表示されませんでした

#変更の影響範囲: 
store()メソッドにおいて、ファイルの保存パスが修正されました。