### PR TITLE
createUser関数でのトークンの返却方法を変更

### DIFF
--- a/laravel-project/app/Http/Controllers/UserController.php
+++ b/laravel-project/app/Http/Controllers/UserController.php
@@ -21,9 +21,9 @@ class UserController extends Controller
 
         $user->save();
 
-        $token = $user->createToken('my-app-token')->plainTextToken;
+        $user->token = $user->createToken('my-app-token')->plainTextToken;
 
-        return ['user' => $user, 'token' => $token];
+        return $user;
     }
 
     private function getImagePathFromImgId($img_id)


### PR DESCRIPTION
#変更内容
 `UserControllerファイルのcreateUser`メソッドを修正して、生成されたトークンを`$user`オブジェクトに直接`token`という新しいプロパティとして割り当てる。

#変更意図
現在新規でアカウントを作成したときのレスポンスが下記のようにuserの中にuserオブジェクトが含まれている。

`{
    "message": "User created successfully",
    "user": {
        "user": {
            "img_id": "2",
            "user_mail": "example@example.com6",
            "user_name": "mac",
            "birth": "2000-02-02",
            "blood_type": "A",
            "height": "100",
            "hobby": "reading",
            "episode1": "Episode 1",
            "episode2": "Episode 2",
            "episode3": "Episode 3",
            "episode4": "Episode 4",
            "episode5": "Episode 5",
            "abilities": null,
            "user_id": 12
        },
        "token": "8|D1VN7qwb24Ds7dN0f8uNGPophiPfPXz6T3eQ292l"
    },
    "img_path": "http://localhost:8000/storage/giftFlow.png"
}`

#変更後の動作確認
作成後のデータの取得、ログイン後の更新処理もできたためトークンも問題ない
